### PR TITLE
feat: Añade comando 'help' a la CLI

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -92,12 +92,22 @@ func initializeApp() (*cli.Command, error) {
 	if err := registerCommand.Register("summarize-pr", prCommand); err != nil {
 		log.Fatalf("Error al registrar el comando 'summarize-pr': %v", err)
 	}
+	commands := registerCommand.CreateCommands()
+	helpCommand := &cli.Command{
+		Name:    "help",
+		Aliases: []string{"h"},
+		Usage:   translations.GetMessage("help_command_usage", 0, nil),
+		Action: func(ctx context.Context, cmd *cli.Command) error {
+			return cli.ShowAppHelp(cmd)
+		},
+	}
+	commands = append(commands, helpCommand)
 
 	return &cli.Command{
 		Name:        "mate-commit",
 		Usage:       translations.GetMessage("app_usage", 0, nil),
 		Version:     "1.3.0",
 		Description: translations.GetMessage("app_description", 0, nil),
-		Commands:    registerCommand.CreateCommands(),
+		Commands:    commands,
 	}, nil
 }

--- a/internal/i18n/locales/active.en.toml
+++ b/internal/i18n/locales/active.en.toml
@@ -300,3 +300,6 @@ for_pr = "❌ AI is not configured. Set your Gemini API Key to use 'summarize-pr
 
 ai_missing_for_suggest = "❌ AI is not configured. Set your Gemini API Key to use 'suggest'.\n   👉 matecommit config init"
 ai_missing_for_pr = "❌ AI is not configured. Set your Gemini API Key to use 'summarize-pr'.\n   👉 matecommit config init"
+
+[help_command_usage]
+other = "Shows a list of commands or help for one command"

--- a/internal/i18n/locales/active.es.toml
+++ b/internal/i18n/locales/active.es.toml
@@ -306,4 +306,10 @@ for_suggest = "❌ La IA no está configurada. Configurá tu API Key de Gemini p
 for_pr = "❌ La IA no está configurada. Configurá tu API Key de Gemini para usar 'summarize-pr'.\n   👉 matecommit config init"
 
 ai_missing_for_suggest = "❌ La IA no está configurada. Configurá tu API Key de Gemini para usar 'suggest'.\n   👉 matecommit config init"
+
 ai_missing_for_pr = "❌ La IA no está configurada. Configurá tu API Key de Gemini para usar 'summarize-pr'.\n   👉 matecommit config init"
+
+
+
+[help_command_usage]
+other = "Muestra una lista de comandos o ayuda para un comando"


### PR DESCRIPTION
- **Implementa el comando `help` en la CLI**:
    - **Propósito:** Facilita a los usuarios el acceso a la ayuda de la aplicación y a la lista de comandos disponibles, utilizando `mate-commit help` o `mate-commit h`.
    - **Impacto técnico:** Se integra un nuevo `cli.Command` en la aplicación principal (`cmd/main.go`), que invoca `cli.ShowAppHelp` para mostrar la información.
- **Agrega traducción en inglés para el uso de `help`**:
    - **Propósito:** Proporcionar un mensaje de uso localizado para el comando `help` cuando el idioma de la aplicación es inglés.
    - **Impacto técnico:** Se añade la clave `help_command_usage` en `internal/i18n/locales/active.en.toml`.
- **Agrega traducción en español para el uso de `help`**:
    - **Propósito:** Proporcionar un mensaje de uso localizado para el comando `help` cuando el idioma de la aplicación es español.
    - **Impacto técnico:** Se añade la clave `help_command_usage` en `internal/i18n/locales/active.es.toml`.