### PR TITLE
refactor(core): Centralize editor and config target resolution

### DIFF
--- a/internal/commands/config/doctor.go
+++ b/internal/commands/config/doctor.go
@@ -12,6 +12,7 @@ import (
 	"github.com/google/go-github/v80/github"
 	"github.com/thomas-vilte/matecommit/internal/ai/gemini"
 	"github.com/thomas-vilte/matecommit/internal/config"
+	"github.com/thomas-vilte/matecommit/internal/editor"
 	"github.com/thomas-vilte/matecommit/internal/i18n"
 	"github.com/thomas-vilte/matecommit/internal/ui"
 	"github.com/urfave/cli/v3"
@@ -226,19 +227,10 @@ func (d *DoctorCommand) checkGeminiAPIKey(ctx context.Context, t *i18n.Translati
 }
 
 func (d *DoctorCommand) checkEditor(_ context.Context, t *i18n.Translations, _ *config.Config) checkResult {
-	editor := os.Getenv("EDITOR")
-	if editor == "" {
-		editors := []string{"nano", "vim", "vi", "code", "emacs"}
-		for _, ed := range editors {
-			if _, err := exec.LookPath(ed); err == nil {
-				return checkResult{
-					status:     checkStatusWarning,
-					message:    t.GetMessage("doctor.editor_not_set", 0, struct{ Editor string }{ed}),
-					suggestion: fmt.Sprintf("export EDITOR=%s", ed),
-				}
-			}
-		}
+	explicitlySet := os.Getenv("EDITOR") != "" || os.Getenv("VISUAL") != ""
 
+	ed, found := editor.Resolve()
+	if !found {
 		return checkResult{
 			status:     checkStatusError,
 			message:    t.GetMessage("doctor.no_editor_found", 0, nil),
@@ -246,17 +238,25 @@ func (d *DoctorCommand) checkEditor(_ context.Context, t *i18n.Translations, _ *
 		}
 	}
 
-	if _, err := exec.LookPath(editor); err != nil {
+	if !explicitlySet {
+		return checkResult{
+			status:     checkStatusWarning,
+			message:    t.GetMessage("doctor.editor_not_set", 0, struct{ Editor string }{ed}),
+			suggestion: fmt.Sprintf("export EDITOR=%s", ed),
+		}
+	}
+
+	if _, err := exec.LookPath(ed); err != nil {
 		return checkResult{
 			status:     checkStatusError,
-			message:    t.GetMessage("doctor.editor_not_found", 0, struct{ Editor string }{editor}),
+			message:    t.GetMessage("doctor.editor_not_found", 0, struct{ Editor string }{ed}),
 			suggestion: t.GetMessage("doctor.set_valid_editor", 0, nil),
 		}
 	}
 
 	return checkResult{
 		status:  checkStatusOK,
-		message: fmt.Sprintf("(%s)", editor),
+		message: fmt.Sprintf("(%s)", ed),
 	}
 }
 

--- a/internal/commands/config/edit.go
+++ b/internal/commands/config/edit.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 
 	"github.com/thomas-vilte/matecommit/internal/config"
+	"github.com/thomas-vilte/matecommit/internal/editor"
 	"github.com/thomas-vilte/matecommit/internal/i18n"
 	"github.com/urfave/cli/v3"
 )
@@ -21,18 +22,12 @@ func (c *ConfigCommandFactory) newEditCommand(t *i18n.Translations, cfg *config.
 
 func editConfigAction(cfg *config.Config, t *i18n.Translations) cli.ActionFunc {
 	return func(ctx context.Context, command *cli.Command) error {
-		editor := os.Getenv("EDITOR")
-		if editor == "" {
-			if _, err := exec.LookPath("nano"); err == nil {
-				editor = "nano"
-			} else if _, err := exec.LookPath("vim"); err == nil {
-				editor = "vim"
-			} else {
-				return fmt.Errorf("%s", t.GetMessage("config_save.error_no_editor", 0, nil))
-			}
+		ed, found := editor.Resolve()
+		if !found {
+			return fmt.Errorf("%s", t.GetMessage("config_save.error_no_editor", 0, nil))
 		}
 
-		cmd := exec.Command(editor, cfg.PathFile)
+		cmd := exec.Command(ed, cfg.PathFile)
 		cmd.Stdin = os.Stdin
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr

--- a/internal/commands/config/init.go
+++ b/internal/commands/config/init.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -54,33 +53,12 @@ func (c *ConfigCommandFactory) newInitCommand(t *i18n.Translations, cfg *config.
 
 func initConfigAction(cfg *config.Config, t *i18n.Translations) cli.ActionFunc {
 	return func(ctx context.Context, command *cli.Command) error {
-		isLocalExplicit := command.Bool("local")
-		isGlobalExplicit := command.Bool("global")
-
-		useLocal := isLocalExplicit
-		if !isGlobalExplicit && !isLocalExplicit {
-			localPath := config.GetRepoConfigPath()
-			useLocal = localPath != ""
+		localCfg, useLocal, err := resolveTargetConfig(command, cfg, t)
+		if err != nil {
+			return err
 		}
 
 		if useLocal {
-			localPath := config.GetRepoConfigPath()
-			if localPath == "" {
-				return errors.New(t.GetMessage("config_local.not_in_repo", 0, nil))
-			}
-
-			localCfg, err := config.LoadConfig(localPath)
-			if err != nil {
-				if os.IsNotExist(err) {
-					localCfg, err = config.CreateDefaultConfig(localPath)
-					if err != nil {
-						return fmt.Errorf("error creating local config: %w", err)
-					}
-				} else {
-					return fmt.Errorf("error loading local config: %w", err)
-				}
-			}
-
 			reader := bufio.NewReader(os.Stdin)
 
 			if command.Bool("quick") {

--- a/internal/commands/config/set.go
+++ b/internal/commands/config/set.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"strconv"
@@ -40,34 +39,9 @@ func (c *ConfigCommandFactory) newSetCommand(t *i18n.Translations, cfg *config.C
 			key := strings.ToLower(command.Args().Get(0))
 			value := command.Args().Get(1)
 
-			isLocalExplicit := command.Bool("local")
-			isGlobalExplicit := command.Bool("global")
-
-			useLocal := isLocalExplicit
-			if !isGlobalExplicit && !isLocalExplicit {
-				localPath := config.GetRepoConfigPath()
-				useLocal = localPath != ""
-			}
-
-			targetCfg := cfg
-			if useLocal {
-				localPath := config.GetRepoConfigPath()
-				if localPath == "" {
-					return errors.New(t.GetMessage("config_local.not_in_repo", 0, nil))
-				}
-
-				localCfg, err := config.LoadConfig(localPath)
-				if err != nil {
-					if os.IsNotExist(err) || errors.Is(err, os.ErrNotExist) {
-						localCfg, err = config.CreateDefaultConfig(localPath)
-						if err != nil {
-							return fmt.Errorf("error creating local config: %w", err)
-						}
-					} else {
-						return fmt.Errorf("error loading local config: %w. Fix the file manually or delete it", err)
-					}
-				}
-				targetCfg = localCfg
+			targetCfg, useLocal, err := resolveTargetConfig(command, cfg, t)
+			if err != nil {
+				return err
 			}
 
 			switch key {
@@ -110,7 +84,6 @@ func (c *ConfigCommandFactory) newSetCommand(t *i18n.Translations, cfg *config.C
 				return fmt.Errorf("unknown configuration key: %s", key)
 			}
 
-			var err error
 			if useLocal {
 				err = config.SaveLocalConfig(targetCfg)
 			} else {

--- a/internal/commands/config/target.go
+++ b/internal/commands/config/target.go
@@ -1,0 +1,49 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/thomas-vilte/matecommit/internal/config"
+	"github.com/thomas-vilte/matecommit/internal/i18n"
+	"github.com/urfave/cli/v3"
+)
+
+// resolveTargetConfig decides whether the local (repo) or global config
+// should be used, based on the --local/--global flags — falling back to
+// auto-detecting a repo config when neither flag is given — and loads (or
+// creates) the local config file when needed. Commands that operate on
+// either the local or global config (init, set) share this resolution.
+func resolveTargetConfig(command *cli.Command, cfg *config.Config, t *i18n.Translations) (target *config.Config, useLocal bool, err error) {
+	isLocalExplicit := command.Bool("local")
+	isGlobalExplicit := command.Bool("global")
+
+	useLocal = isLocalExplicit
+	if !isGlobalExplicit && !isLocalExplicit {
+		useLocal = config.GetRepoConfigPath() != ""
+	}
+
+	if !useLocal {
+		return cfg, false, nil
+	}
+
+	localPath := config.GetRepoConfigPath()
+	if localPath == "" {
+		return nil, true, errors.New(t.GetMessage("config_local.not_in_repo", 0, nil))
+	}
+
+	localCfg, loadErr := config.LoadConfig(localPath)
+	if loadErr != nil {
+		if os.IsNotExist(loadErr) || errors.Is(loadErr, os.ErrNotExist) {
+			localCfg, loadErr = config.CreateDefaultConfig(localPath)
+			if loadErr != nil {
+				return nil, true, fmt.Errorf("error creating local config: %w", loadErr)
+			}
+		} else {
+			return nil, true, fmt.Errorf("error loading local config: %w", loadErr)
+		}
+	}
+
+	return localCfg, true, nil
+}

--- a/internal/commands/release/edit.go
+++ b/internal/commands/release/edit.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 
 	"github.com/thomas-vilte/matecommit/internal/commands/completion_helper"
+	"github.com/thomas-vilte/matecommit/internal/editor"
 	"github.com/thomas-vilte/matecommit/internal/i18n"
 	"github.com/thomas-vilte/matecommit/internal/models"
 	"github.com/thomas-vilte/matecommit/internal/ui"
@@ -163,17 +164,8 @@ func generateReleaseTemplate(name string, trans *i18n.Translations) string {
 	)
 }
 func getDefaultEditor() string {
-	if editor := os.Getenv("EDITOR"); editor != "" {
-		return editor
-	}
-	if editor := os.Getenv("VISUAL"); editor != "" {
-		return editor
-	}
-	if _, err := exec.LookPath("nano"); err == nil {
-		return "nano"
-	}
-	if _, err := exec.LookPath("vim"); err == nil {
-		return "vim"
+	if ed, found := editor.Resolve(); found {
+		return ed
 	}
 	return "vi"
 }

--- a/internal/editor/editor.go
+++ b/internal/editor/editor.go
@@ -1,0 +1,29 @@
+// Package editor resolves which text editor to use for interactive edits
+// (config files, release notes, etc.), shared by the commands that need it.
+package editor
+
+import (
+	"os"
+	"os/exec"
+)
+
+// candidates is tried, in order, when neither $EDITOR nor $VISUAL is set.
+var candidates = []string{"nano", "vim", "vi", "code", "emacs"}
+
+// Resolve returns the user's preferred editor: $EDITOR, then $VISUAL, then
+// the first of a list of common editors found on PATH. It returns
+// ("", false) when none could be determined.
+func Resolve() (string, bool) {
+	if e := os.Getenv("EDITOR"); e != "" {
+		return e, true
+	}
+	if e := os.Getenv("VISUAL"); e != "" {
+		return e, true
+	}
+	for _, c := range candidates {
+		if _, err := exec.LookPath(c); err == nil {
+			return c, true
+		}
+	}
+	return "", false
+}

--- a/internal/editor/editor_test.go
+++ b/internal/editor/editor_test.go
@@ -1,0 +1,38 @@
+package editor
+
+import "testing"
+
+func TestResolve(t *testing.T) {
+	t.Run("prefers EDITOR", func(t *testing.T) {
+		t.Setenv("EDITOR", "my-editor")
+		t.Setenv("VISUAL", "my-visual")
+
+		ed, found := Resolve()
+		if !found || ed != "my-editor" {
+			t.Errorf("Resolve() = (%q, %v), want (\"my-editor\", true)", ed, found)
+		}
+	})
+
+	t.Run("falls back to VISUAL when EDITOR is unset", func(t *testing.T) {
+		t.Setenv("EDITOR", "")
+		t.Setenv("VISUAL", "my-visual")
+
+		ed, found := Resolve()
+		if !found || ed != "my-visual" {
+			t.Errorf("Resolve() = (%q, %v), want (\"my-visual\", true)", ed, found)
+		}
+	})
+
+	t.Run("falls back to PATH candidates when neither is set", func(t *testing.T) {
+		t.Setenv("EDITOR", "")
+		t.Setenv("VISUAL", "")
+
+		ed, found := Resolve()
+		if !found {
+			t.Skip("no candidate editor available on PATH in this environment")
+		}
+		if ed == "" {
+			t.Error("Resolve() returned found=true with an empty editor name")
+		}
+	})
+}


### PR DESCRIPTION
## Description
I have centralized the logic for resolving the preferred text editor and for determining the target configuration (local vs. global).

Previously, the logic for finding an editor was duplicated across multiple command files. Similarly, the logic for resolving whether to use local or global configuration was repeated in `config init` and `config set` commands.

This refactor introduces:
- A new `internal/editor` package with a `Resolve()` function to consistently determine the user's preferred text editor by checking `$EDITOR`, `$VISUAL`, and common editors on `PATH`.
- A new `resolveTargetConfig` function in `internal/commands/config/target.go` to centralize the decision-making process for which configuration file (local or global) to operate on.

This centralization significantly reduces code duplication, improves maintainability, and makes the editor and config resolution logic more robust and testable.

Fixes # (issue)

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [x] Unit tests (New unit tests were added for the `internal/editor` package.)
- [ ] Integration tests
- [x] Manual test: (Existing commands that utilize editor resolution (`config edit`, `release edit`, `doctor`) and config target resolution (`config init`, `config set`) were manually tested to ensure no regressions and correct behavior.)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (specifically for editor resolution)
- [x] New and existing unit tests pass locally with my changes

## 🧪 Test Plan & Evidence

### Suggested Manual Verification
- [x] **Unit Tests**: Run `go test ./...` and ensure all tests pass
- [x] **No Regressions**: Verify that related features still work as expected
