### PR TITLE
Fix: Correct GitHub file path retrieval and enhance release error handling

### DIFF
--- a/internal/vcs/github/client.go
+++ b/internal/vcs/github/client.go
@@ -397,7 +397,7 @@ func (ghc *GitHubClient) CreateRelease(ctx context.Context, release *models.Rele
 func (ghc *GitHubClient) GetRelease(ctx context.Context, version string) (*models.VCSRelease, error) {
 	release, resp, err := ghc.releaseService.GetReleaseByTag(ctx, ghc.owner, ghc.repo, version)
 	if err != nil {
-		if resp != nil && resp.StatusCode == 404 {
+		if resp != nil {
 			if resp.StatusCode == http.StatusUnauthorized {
 				return nil, domainErrors.ErrGitHubTokenInvalid.
 					WithContext("operation", "get release").
@@ -792,7 +792,7 @@ func (ghc *GitHubClient) GetFileAtTag(ctx context.Context, tag, filepath string)
 		Ref: tag,
 	}
 
-	fileContent, _, _, err := ghc.repoService.GetContents(ctx, ghc.owner, ghc.repo, tag, opts)
+	fileContent, _, _, err := ghc.repoService.GetContents(ctx, ghc.owner, ghc.repo, filepath, opts)
 	if err != nil {
 		return "", err
 	}

--- a/internal/vcs/github/client_test.go
+++ b/internal/vcs/github/client_test.go
@@ -569,6 +569,25 @@ func TestGitHubClient_GetRelease(t *testing.T) {
 		mockRelease.AssertExpectations(t)
 	})
 
+	t.Run("should return error if token is invalid (401)", func(t *testing.T) {
+		mockPR := &MockPRService{}
+		mockIssues := &MockIssuesService{}
+		mockRelease := &MockReleaseService{}
+		mockUserService := &MockUserService{}
+		client := newTestClient(mockPR, mockIssues, mockRelease, mockUserService)
+
+		resp := &github.Response{Response: &http.Response{StatusCode: http.StatusUnauthorized}}
+		mockRelease.On("GetReleaseByTag", mock.Anything, "test-owner", "test-repo", "v1.0.0").
+			Return((*github.RepositoryRelease)(nil), resp, assert.AnError)
+
+		release, err := client.GetRelease(context.Background(), "v1.0.0")
+
+		assert.Error(t, err)
+		assert.Nil(t, release)
+		assert.Contains(t, err.Error(), "token")
+		mockRelease.AssertExpectations(t)
+	})
+
 	t.Run("should return generic error for other failures", func(t *testing.T) {
 		mockPR := &MockPRService{}
 		mockIssues := &MockIssuesService{}
@@ -1125,7 +1144,7 @@ func TestGitHubClient_GetFileAtTag(t *testing.T) {
 		expectedContent := "test content"
 		encodedContent := "dGVzdCBjb250ZW50"
 
-		mockRepo.On("GetContents", mock.Anything, "test-owner", "test-repo", tag, &github.RepositoryContentGetOptions{Ref: tag}).
+		mockRepo.On("GetContents", mock.Anything, "test-owner", "test-repo", filepath, &github.RepositoryContentGetOptions{Ref: tag}).
 			Return(&github.RepositoryContent{
 				Content:  github.Ptr(encodedContent),
 				Encoding: github.Ptr("base64"),
@@ -1150,7 +1169,7 @@ func TestGitHubClient_GetFileAtTag(t *testing.T) {
 		tag := "v1.0.0"
 		filepath := "test.txt"
 
-		mockRepo.On("GetContents", mock.Anything, "test-owner", "test-repo", tag, &github.RepositoryContentGetOptions{Ref: tag}).
+		mockRepo.On("GetContents", mock.Anything, "test-owner", "test-repo", filepath, &github.RepositoryContentGetOptions{Ref: tag}).
 			Return((*github.RepositoryContent)(nil), []*github.RepositoryContent{}, &github.Response{}, nil)
 
 		_, err := client.GetFileAtTag(context.Background(), tag, filepath)
@@ -1170,7 +1189,7 @@ func TestGitHubClient_GetFileAtTag(t *testing.T) {
 
 		tag := "v1.0.0"
 
-		mockRepo.On("GetContents", mock.Anything, "test-owner", "test-repo", tag, mock.Anything).
+		mockRepo.On("GetContents", mock.Anything, "test-owner", "test-repo", "test.txt", mock.Anything).
 			Return((*github.RepositoryContent)(nil), []*github.RepositoryContent{}, &github.Response{}, assert.AnError)
 
 		_, err := client.GetFileAtTag(context.Background(), tag, "test.txt")


### PR DESCRIPTION
## Description
I have corrected the `GetFileAtTag` function to properly use the `filepath` parameter when calling `repoService.GetContents`, resolving an issue where the file path was being incorrectly passed as the tag.

Additionally, I have enhanced the error handling in the `GetRelease` function. It now specifically checks for `http.StatusUnauthorized` (401) responses from the GitHub API and returns `domainErrors.ErrGitHubTokenInvalid` when an invalid token is detected during release retrieval. This provides clearer error feedback.

Fixes #

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
I have verified these changes through unit tests.

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual test: (describe below)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## 🧪 Test Plan & Evidence

### Suggested Manual Verification
- [x] **Unit Tests**: Run `go test ./...` and ensure all tests pass
- [x] **No Regressions**: Verify that related features still work as expected
