### PR TITLE
Enforce strict multi-line Markdown format for AI-generated issue descriptions

### DIFF
--- a/internal/ai/gemini/issue_content_generator.go
+++ b/internal/ai/gemini/issue_content_generator.go
@@ -83,7 +83,7 @@ func getIssueSchema() *genai.Schema {
 			},
 			"description": {
 				Type:        genai.TypeString,
-				Description: "The body of the issue in markdown format",
+				Description: "The body of the issue written as an actual multi-line Markdown document, with real line breaks between headers and paragraphs — like a person typing in a text editor, not a single run-on line. Never write the two-character escape sequence (backslash followed by n) as literal text in place of a line break, and never collapse sections into a single line of prose.",
 			},
 			"labels": {
 				Type: genai.TypeArray,

--- a/internal/ai/prompts.go
+++ b/internal/ai/prompts.go
@@ -675,6 +675,7 @@ const (
   3. **Accurate Categorization:** Always choose at least one primary category: 'feature', 'fix', or 'refactor'. Use 'fix' ONLY for bug corrections. Use 'refactor' for code improvements without logic changes. Use 'feature' for new functionality.
   4. **No Emojis:** Do not use emojis in the title or description. Keep it purely textual and professional.
   5. **Balanced Labeling:** Aim for 2-4 relevant labels. Ensure you include the primary category plus any relevant file-based labels like 'test', 'docs', or 'infra' if applicable.
+  6. **Markdown Format (STRICT):** Write the "description" field as an actual multi-line Markdown document — press enter between lines like a real document, do NOT type the two-character escape sequence (backslash followed by the letter n) as literal text anywhere in the body. Each "### Header" goes on its own line followed by a blank line before the paragraph under it. NEVER collapse multiple sections into a single run-on paragraph.
 
   Generate the issue now.`
 
@@ -690,6 +691,7 @@ const (
   3. **Categorización Precisa:** Elegí siempre al menos una categoría principal: 'feature', 'fix', o 'refactor'. Solo usá 'fix' si ves una corrección de un bug. Usá 'refactor' para mejoras de código sin cambios lógicos. Usá 'feature' para funcionalidades nuevas.
   4. **Cero Emojis:** No uses emojis ni en el título ni en el cuerpo del issue. Mantené un estilo sobrio y técnico.
   5. **Etiquetado Equilibrado:** Buscá entre 2 y 4 etiquetas relevantes. Asegurate de incluir la categoría principal más cualquier etiqueta de tipo de archivo como 'test', 'docs', o 'infra' si corresponde.
+  6. **Formato Markdown (ESTRICTO):** Escribí el campo "description" como un documento Markdown real de varias líneas — apretá enter entre líneas como en un documento de verdad, NO escribas la secuencia de escape de dos caracteres (barra invertida seguida de la letra n) como texto literal en ningún lugar del body. Cada "### Encabezado" va en su propia línea seguido de una línea en blanco antes del párrafo. NUNCA mezcles varias secciones en un solo párrafo de texto corrido.
 
   Generá el issue ahora. Responde en ESPAÑOL.`
 


### PR DESCRIPTION
## Description
I have updated the AI's issue content generation to strictly enforce multi-line Markdown formatting for the `description` field. This change modifies the Gemini schema and the internal prompts to explicitly instruct the AI to generate descriptions with real line breaks between headers, paragraphs, and list items, rather than using `\n` escape sequences or collapsing sections into a single line.

This ensures that AI-generated issue descriptions are naturally formatted, readable Markdown documents, mirroring how a person would type them in a text editor.

Fixes #

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual test: (describe below)

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test Plan & Evidence

### Suggested Manual Verification
- [x] **Unit Tests**: Run `go test ./...` and ensure all tests pass
- [x] **No Regressions**: Verify that related features still work as expected
