### PR TITLE
feat(ai): Skip AI cost confirmation for internal orchestration calls

### DIFF
--- a/internal/ai/gemini/issue_content_generator.go
+++ b/internal/ai/gemini/issue_content_generator.go
@@ -142,6 +142,11 @@ func (s *GeminiIssueContentGenerator) GenerateIssueContent(ctx context.Context, 
 	log.Debug("calling gemini API for issue content",
 		"prompt_length", len(prompt))
 
+	if request.SkipConfirmation {
+		s.wrapper.SetSkipConfirmation(true)
+		defer s.wrapper.SetSkipConfirmation(false)
+	}
+
 	var usage *models.TokenUsage
 	var responseText string
 

--- a/internal/ai/gemini/issue_content_generator_test.go
+++ b/internal/ai/gemini/issue_content_generator_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/thomas-vilte/matecommit/internal/ai"
 	"github.com/thomas-vilte/matecommit/internal/config"
 	"github.com/thomas-vilte/matecommit/internal/models"
 	"google.golang.org/genai"
@@ -441,5 +442,71 @@ func TestGenerateIssueContent_HappyPath(t *testing.T) {
 		assert.Equal(t, "Issue Title", result.Title)
 		assert.Equal(t, "Issue Description", result.Description)
 		assert.Contains(t, result.Labels, "fix")
+	})
+}
+
+// TestGenerateIssueContent_SkipConfirmation verifies that a request with
+// SkipConfirmation bypasses the cost confirmation prompt (used for internal
+// orchestration calls like template auto-selection), while a normal request
+// still goes through it — so the user isn't asked twice for one logical
+// "generate an issue" action.
+func TestGenerateIssueContent_SkipConfirmation(t *testing.T) {
+	tmpHome, err := os.MkdirTemp("", "matecommit-test-issue-skip-*")
+	assert.NoError(t, err)
+	defer func() {
+		if err := os.RemoveAll(tmpHome); err != nil {
+			return
+		}
+	}()
+	oldHome := os.Getenv("HOME")
+	_ = os.Setenv("HOME", tmpHome)
+	defer func() {
+		if err := os.Setenv("HOME", oldHome); err != nil {
+			return
+		}
+	}()
+
+	ctx := context.Background()
+	cfg := &config.Config{
+		AIProviders: map[string]config.AIProviderConfig{"gemini": {APIKey: "test"}},
+		AIConfig:    config.AIConfig{Models: map[config.AI]config.Model{config.AIGemini: "gemini-pro"}},
+	}
+
+	confirmationCalls := 0
+	onConfirmation := func(ai.ConfirmationResult) (string, bool) {
+		confirmationCalls++
+		return "current", true
+	}
+
+	gen, err := NewGeminiIssueContentGenerator(ctx, cfg, onConfirmation)
+	assert.NoError(t, err)
+
+	expectedJSON := `{"title": "Issue Title", "description": "Issue Description", "labels": ["fix"]}`
+	gen.generateFn = func(ctx context.Context, mName string, p string) (interface{}, *models.TokenUsage, error) {
+		return &genai.GenerateContentResponse{
+			Candidates: []*genai.Candidate{
+				{Content: &genai.Content{Parts: []*genai.Part{{Text: expectedJSON}}}},
+			},
+		}, &models.TokenUsage{TotalTokens: 30}, nil
+	}
+
+	t.Run("normal request triggers confirmation", func(t *testing.T) {
+		_, err := gen.GenerateIssueContent(ctx, models.IssueGenerationRequest{Description: "unique-prompt-1"})
+		assert.NoError(t, err)
+		assert.Equal(t, 1, confirmationCalls, "confirmation should have been requested")
+	})
+
+	t.Run("SkipConfirmation bypasses the prompt", func(t *testing.T) {
+		confirmationCalls = 0
+		_, err := gen.GenerateIssueContent(ctx, models.IssueGenerationRequest{Description: "unique-prompt-2", SkipConfirmation: true})
+		assert.NoError(t, err)
+		assert.Equal(t, 0, confirmationCalls, "confirmation should have been skipped")
+	})
+
+	t.Run("wrapper returns to normal confirmation behavior afterwards", func(t *testing.T) {
+		confirmationCalls = 0
+		_, err := gen.GenerateIssueContent(ctx, models.IssueGenerationRequest{Description: "unique-prompt-3"})
+		assert.NoError(t, err)
+		assert.Equal(t, 1, confirmationCalls, "confirmation should be re-enabled after a SkipConfirmation call")
 	})
 }

--- a/internal/models/issue_generation.go
+++ b/internal/models/issue_generation.go
@@ -23,6 +23,12 @@ type IssueGenerationRequest struct {
 
 	// AvailableLabels is the list of labels available in the repository (optional)
 	AvailableLabels []string
+
+	// SkipConfirmation bypasses the cost confirmation prompt for this call.
+	// Used for small internal orchestration calls (e.g. template
+	// auto-selection) that shouldn't interrupt the user twice for what
+	// they experience as a single logical action.
+	SkipConfirmation bool
 }
 
 // IssueGenerationResult contains the result of an issue's content generation.

--- a/internal/services/issue_generator_service.go
+++ b/internal/services/issue_generator_service.go
@@ -458,6 +458,9 @@ If no template fits perfectly, choose "Custom Issue" or the most generic one.`, 
 	request := models.IssueGenerationRequest{
 		Description: prompt,
 		Language:    "en",
+		// This is a small internal call to pick a template, not the user's
+		// actual issue content — don't make them confirm cost for it too.
+		SkipConfirmation: true,
 	}
 
 	result, err := s.ai.GenerateIssueContent(ctx, request)


### PR DESCRIPTION
## Description
I implemented a mechanism to skip the AI cost confirmation prompt for internal orchestration calls. This change introduces a `SkipConfirmation` flag in the `IssueGenerationRequest` model. When set to `true`, the Gemini AI wrapper will bypass the interactive cost confirmation, preventing redundant prompts for the user during multi-step AI operations.

This is particularly useful for scenarios like automatic issue template selection, where the system makes a small internal AI call that shouldn't interrupt the user with a separate cost confirmation, as they are already in the process of generating an issue.

Fixes #

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
I added a new unit test `TestGenerateIssueContent_SkipConfirmation` in `internal/ai/gemini/issue_content_generator_test.go`.

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual test: (describe below)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test Plan & Evidence

### Suggested Manual Verification
- [x] **API/Backend**: Attach JSON response or logs as evidence of correct behavior
- [x] **Performance**: Ensure no significant latency increase
- [x] **Unit Tests**: Run `go test ./...` and ensure all tests pass
- [x] **No Regressions**: Verify that related features still work as expected
