### PR TITLE
Fix config show: Correctly label config type and prevent duplication

### DIFF
--- a/internal/commands/config/show.go
+++ b/internal/commands/config/show.go
@@ -14,7 +14,17 @@ func (c *ConfigCommandFactory) newShowCommand(t *i18n.Translations, cfg *config.
 		Name:  "show",
 		Usage: t.GetMessage("config_show_usage", 0, nil),
 		Action: func(ctx context.Context, command *cli.Command) error {
-			fmt.Println(t.GetMessage("config_local.global_config_header", 0, nil))
+			// LoadConfigWithHierarchy resolves to the repo-local config
+			// entirely whenever one exists (not a field-by-field merge with
+			// global) — so `cfg` here is local data whenever we're inside a
+			// git repo, and it must be labeled as such instead of always
+			// saying "Global".
+			isLocal := config.GetRepoConfigPath() != ""
+			if isLocal {
+				fmt.Println(t.GetMessage("config_local.local_config_header", 0, nil))
+			} else {
+				fmt.Println(t.GetMessage("config_local.global_config_header", 0, nil))
+			}
 			fmt.Printf("━━━━━━━━━━━━━━━━━━━━━━━\n")
 
 			fmt.Printf("%s\n", t.GetMessage("language_label", 0, struct{ Lang string }{cfg.Language}))
@@ -69,30 +79,6 @@ func (c *ConfigCommandFactory) newShowCommand(t *i18n.Translations, cfg *config.
 				}
 				if cfg.GitFallback.UserEmail != "" {
 					fmt.Printf("%s\n", t.GetMessage("config_git.fallback_email", 0, struct{ Email string }{cfg.GitFallback.UserEmail}))
-				}
-			}
-
-			localPath := config.GetRepoConfigPath()
-			if localPath != "" {
-				localCfg, err := config.LoadConfig(localPath)
-				if err == nil {
-					fmt.Println()
-					fmt.Println(t.GetMessage("config_local.local_config_header", 0, nil))
-					fmt.Printf("━━━━━━━━━━━━━━━━━━━━━━━\n")
-					fmt.Printf("%s\n", t.GetMessage("language_label", 0, struct{ Lang string }{localCfg.Language}))
-					fmt.Printf("%s\n", t.GetMessage("emojis_label", 0, struct{ Emoji bool }{localCfg.UseEmoji}))
-					fmt.Printf("%s\n", t.GetMessage("config_models.active_ai_label", 0, struct{ IA config.AI }{localCfg.AIConfig.ActiveAI}))
-
-					if localCfg.GitFallback.UserName != "" || localCfg.GitFallback.UserEmail != "" {
-						fmt.Println()
-						fmt.Println(t.GetMessage("config_git.fallback_header", 0, nil))
-						if localCfg.GitFallback.UserName != "" {
-							fmt.Printf("%s\n", t.GetMessage("config_git.fallback_name", 0, struct{ Name string }{localCfg.GitFallback.UserName}))
-						}
-						if localCfg.GitFallback.UserEmail != "" {
-							fmt.Printf("%s\n", t.GetMessage("config_git.fallback_email", 0, struct{ Email string }{localCfg.GitFallback.UserEmail}))
-						}
-					}
 				}
 			}
 

--- a/internal/commands/config/show_test.go
+++ b/internal/commands/config/show_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"io"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -113,5 +114,43 @@ func TestShowCommand(t *testing.T) {
 
 		assert.Contains(t, output, "gemini: gemini-1.5-flash")
 		assert.Contains(t, output, "openai: gpt-4o")
+	})
+
+	t.Run("labels the resolved config as local (not global) when run inside a repo, with no duplicate section", func(t *testing.T) {
+		// Inside a git repo, LoadConfigWithHierarchy resolves entirely to
+		// the local config (not a merge with global) — the display must
+		// reflect that, and must not print the same data twice under both
+		// a "Global" and a "Local" header.
+		cfg, translations, _, cleanup := setupConfigTest(t)
+		cfg.GitFallback = config.GitConfig{UserName: "Fallback Name", UserEmail: "fallback@example.com"}
+		assert.NoError(t, config.SaveConfig(cfg))
+		defer cleanup()
+
+		oldStdout := os.Stdout
+		r, w, _ := os.Pipe()
+		os.Stdout = w
+
+		cmd := NewConfigCommandFactory().newShowCommand(translations, cfg)
+		app := &cli.Command{Commands: []*cli.Command{cmd}}
+
+		err := app.Run(context.Background(), []string{"config", "show"})
+
+		if err := w.Close(); err != nil {
+			assert.NoError(t, err)
+		}
+		os.Stdout = oldStdout
+		var buf bytes.Buffer
+		if _, err := io.Copy(&buf, r); err != nil {
+			assert.NoError(t, err)
+		}
+		output := buf.String()
+
+		assert.NoError(t, err)
+		assert.Contains(t, output, "Local Configuration")
+		assert.NotContains(t, output, "Global Configuration")
+		assert.Equal(t, 1, strings.Count(output, "Fallback Name"),
+			"the fallback identity should be printed exactly once, not duplicated across sections")
+		assert.Equal(t, 1, strings.Count(output, "━━━━━━━━━━━━━━━━━━━━━━━"),
+			"there should be exactly one configuration section header")
 	})
 }


### PR DESCRIPTION
## Description
The `config show` command previously always printed "Global Configuration" initially, and then, if a local repository configuration existed, it would load and print it again under a "Local Configuration" header. This led to incorrect labeling (showing "Global" when a local config was active) and duplication of configuration details.

I've modified `internal/commands/config/show.go` to correctly identify if the active configuration is local (when inside a Git repository) or global, and print the appropriate header only once. This also removes the redundant logic that re-loaded and re-printed the local configuration.

Fixes # (issue)

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
A new unit test `labels the resolved config as local (not global) when run inside a repo, with no duplicate section` was added in `internal/commands/config/show_test.go`. This test verifies that the output correctly identifies the configuration as "Local Configuration" when applicable, does not show "Global Configuration" in that scenario, and ensures that configuration details (like fallback identity) are printed exactly once.

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual test: (describe below)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test Plan & Evidence

### Suggested Manual Verification
- [x] **Unit Tests**: Run `go test ./...` and ensure all tests pass
- [x] **No Regressions**: Verify that related features still work as expected
