### PR TITLE
Refactor: Update config set success message to use templates

### DIFF
--- a/internal/i18n/locales/active.en.toml
+++ b/internal/i18n/locales/active.en.toml
@@ -56,7 +56,7 @@ other = "<key> <value>"
 other = "Missing arguments. Usage: config set <key> <value>"
 
 [config_set_success]
-other = "Configuration updated: %s = %s"
+other = "Configuration updated ({{.Scope}}): {{.Key}} = {{.Value}}"
 
 [config_command_usage]
 other = "Manage configuration"

--- a/internal/i18n/locales/active.es.toml
+++ b/internal/i18n/locales/active.es.toml
@@ -56,7 +56,7 @@ other = "<clave> <valor>"
 other = "Faltan argumentos. Uso: config set <clave> <valor>"
 
 [config_set_success]
-other = "Configuración actualizada: %s = %s"
+other = "Configuración actualizada ({{.Scope}}): {{.Key}} = {{.Value}}"
 
 [config_command_usage]
 other = "Gestiona la configuración de la aplicación"


### PR DESCRIPTION
## Description
I updated the `config_set_success` message in the English and Spanish i18n locale files to use Go template syntax for placeholders. Instead of `%s`, the message now uses `{{.Scope}}`, `{{.Key}}`, and `{{.Value}}` to provide more explicit context within the success message.

Fixes # 

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
I verified the change by running the `config set` command and observing the updated output message.

- [ ] Unit tests
- [ ] Integration tests
- [x] Manual test: Verified `config set` command output.

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test Plan & Evidence

### Suggested Manual Verification
- [x] **No Regressions**: Verify that related features still work as expected
