### PR TITLE
Fix: Improve CLI error handling and stats value formatting

### DIFF
--- a/internal/commands/config/init.go
+++ b/internal/commands/config/init.go
@@ -55,6 +55,7 @@ func initConfigAction(cfg *config.Config, t *i18n.Translations) cli.ActionFunc {
 	return func(ctx context.Context, command *cli.Command) error {
 		localCfg, useLocal, err := resolveTargetConfig(command, cfg, t)
 		if err != nil {
+			ui.PrintError(os.Stdout, err.Error())
 			return err
 		}
 

--- a/internal/commands/config/set.go
+++ b/internal/commands/config/set.go
@@ -41,6 +41,7 @@ func (c *ConfigCommandFactory) newSetCommand(t *i18n.Translations, cfg *config.C
 
 			targetCfg, useLocal, err := resolveTargetConfig(command, cfg, t)
 			if err != nil {
+				ui.PrintError(os.Stdout, err.Error())
 				return err
 			}
 
@@ -49,18 +50,24 @@ func (c *ConfigCommandFactory) newSetCommand(t *i18n.Translations, cfg *config.C
 				if isValidLanguage(value) {
 					targetCfg.Language = value
 				} else {
-					return fmt.Errorf("invalid language: %s", value)
+					err := fmt.Errorf("invalid language: %s", value)
+					ui.PrintError(os.Stdout, err.Error())
+					return err
 				}
 			case "emoji", "use_emoji":
-				boolVal, err := strconv.ParseBool(value)
-				if err != nil {
-					return fmt.Errorf("invalid boolean value: %s", value)
+				boolVal, parseErr := strconv.ParseBool(value)
+				if parseErr != nil {
+					err := fmt.Errorf("invalid boolean value: %s", value)
+					ui.PrintError(os.Stdout, err.Error())
+					return err
 				}
 				targetCfg.UseEmoji = boolVal
 			case "count", "suggestions_count":
-				intVal, err := strconv.Atoi(value)
-				if err != nil || intVal < 1 || intVal > 10 {
-					return fmt.Errorf("invalid count (must be 1-10): %s", value)
+				intVal, parseErr := strconv.Atoi(value)
+				if parseErr != nil || intVal < 1 || intVal > 10 {
+					err := fmt.Errorf("invalid count (must be 1-10): %s", value)
+					ui.PrintError(os.Stdout, err.Error())
+					return err
 				}
 				targetCfg.SuggestionsCount = intVal
 			case "active-ai", "active_ai":
@@ -72,7 +79,9 @@ func (c *ConfigCommandFactory) newSetCommand(t *i18n.Translations, cfg *config.C
 					}
 					targetCfg.AIConfig.Models[targetCfg.AIConfig.ActiveAI] = config.Model(value)
 				} else {
-					return fmt.Errorf("no active AI provider configured")
+					err := fmt.Errorf("no active AI provider configured")
+					ui.PrintError(os.Stdout, err.Error())
+					return err
 				}
 			case "active-vcs", "active_vcs":
 				targetCfg.ActiveVCSProvider = value
@@ -81,7 +90,9 @@ func (c *ConfigCommandFactory) newSetCommand(t *i18n.Translations, cfg *config.C
 			case "git.email", "git-email":
 				targetCfg.GitFallback.UserEmail = value
 			default:
-				return fmt.Errorf("unknown configuration key: %s", key)
+				err := fmt.Errorf("unknown configuration key: %s", key)
+				ui.PrintError(os.Stdout, err.Error())
+				return err
 			}
 
 			if useLocal {

--- a/internal/commands/issues/templates.go
+++ b/internal/commands/issues/templates.go
@@ -37,7 +37,7 @@ func (f *IssuesCommandFactory) newTemplateCommand(t *i18n.Translations, _ *confi
 					ui.PrintInfo(t.GetMessage("issue.template_init_info", 0, nil))
 
 					if err := templateService.InitializeTemplates(ctx, force); err != nil {
-						ui.PrintError(os.Stdout, fmt.Sprintf("%s: %v", t.GetMessage("issue.template_init_error", 0, nil), err))
+						ui.HandleAppError(err, t)
 						return err
 					}
 
@@ -54,7 +54,7 @@ func (f *IssuesCommandFactory) newTemplateCommand(t *i18n.Translations, _ *confi
 				Action: func(ctx context.Context, cmd *cli.Command) error {
 					templates, err := templateService.ListTemplates(ctx)
 					if err != nil {
-						ui.PrintError(os.Stdout, fmt.Sprintf("%s: %v", t.GetMessage("issue.template_list_error", 0, nil), err))
+						ui.HandleAppError(err, t)
 						return err
 					}
 

--- a/internal/commands/stats/stats.go
+++ b/internal/commands/stats/stats.go
@@ -123,7 +123,7 @@ func (c *StatsCommand) showDailyStats(manager *cost.Manager, t *i18n.Translation
 	fmt.Println()
 	fmt.Println("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
 	_, _ = cyan.Printf("%s: ", t.GetMessage("stats.total_today", 0, nil))
-	_, _ = yellow.Println(t.GetMessage("stats.total_today_value", 0, struct{ Total float64 }{total}))
+	_, _ = yellow.Println(t.GetMessage("stats.total_today_value", 0, struct{ Total string }{fmt.Sprintf("%.4f", total)}))
 	fmt.Println("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
 	fmt.Println()
 
@@ -203,7 +203,7 @@ func (c *StatsCommand) showMonthlyStats(manager *cost.Manager, t *i18n.Translati
 	fmt.Println()
 	fmt.Println("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
 	_, _ = cyan.Printf("%s: ", t.GetMessage("stats.total_month", 0, nil))
-	_, _ = yellow.Println(t.GetMessage("stats.total_month_value", 0, struct{ Total float64 }{total}))
+	_, _ = yellow.Println(t.GetMessage("stats.total_month_value", 0, struct{ Total string }{fmt.Sprintf("%.4f", total)}))
 
 	daysWithActivity := len(dailyTotals)
 	if daysWithActivity > 0 {
@@ -221,8 +221,8 @@ func (c *StatsCommand) showMonthlyStats(manager *cost.Manager, t *i18n.Translati
 				Current int
 				Total   int
 			}{forecast.DaysElapsed, forecast.DaysInMonth}))
-			_, _ = dim.Printf("   %s\n", t.GetMessage("stats.forecast_daily_avg_label", 0, struct{ Avg float64 }{forecast.DailyAverage}))
-			_, _ = yellow.Printf("   %s\n", t.GetMessage("stats.forecast_projected_label", 0, struct{ Amount float64 }{forecast.ProjectedMonthEnd}))
+			_, _ = dim.Printf("   %s\n", t.GetMessage("stats.forecast_daily_avg_label", 0, struct{ Avg string }{fmt.Sprintf("%.4f", forecast.DailyAverage)}))
+			_, _ = yellow.Printf("   %s\n", t.GetMessage("stats.forecast_projected_label", 0, struct{ Amount string }{fmt.Sprintf("%.4f", forecast.ProjectedMonthEnd)}))
 			fmt.Println()
 		}
 	}
@@ -230,9 +230,9 @@ func (c *StatsCommand) showMonthlyStats(manager *cost.Manager, t *i18n.Translati
 	hitRate, saved, err := manager.GetCacheStats()
 	if err == nil && hitRate > 0 {
 		_, _ = green.Println(t.GetMessage("stats.cache_hit_rate_label", 0, struct {
-			Rate  float64
-			Saved float64
-		}{hitRate, saved}))
+			Rate  string
+			Saved string
+		}{fmt.Sprintf("%.1f", hitRate), fmt.Sprintf("%.4f", saved)}))
 		fmt.Println()
 	}
 
@@ -329,7 +329,7 @@ func (c *StatsCommand) showBreakdown(manager *cost.Manager, t *i18n.Translations
 
 	for _, stat := range breakdown.ByCommand {
 		if stat.Command == "suggest" && stat.CallCount > 0 {
-			_, _ = green.Println(t.GetMessage("stats.avg_cost_per_commit_label", 0, struct{ Cost float64 }{stat.AvgCost}))
+			_, _ = green.Println(t.GetMessage("stats.avg_cost_per_commit_label", 0, struct{ Cost string }{fmt.Sprintf("%.4f", stat.AvgCost)}))
 			fmt.Println()
 			break
 		}

--- a/internal/commands/stats/stats_test.go
+++ b/internal/commands/stats/stats_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/fatih/color"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/thomas-vilte/matecommit/internal/cost"
@@ -120,6 +121,44 @@ func TestShowDailyStats_WithActivity(t *testing.T) {
 	total, err := manager.GetDailyTotal()
 	assert.NoError(t, err)
 	assert.Equal(t, 0.0100, total, "the calculated total should be 0.0100")
+}
+
+func TestShowDailyStats_TotalIsFormattedCleanly(t *testing.T) {
+	// 0.1 + 0.2 is the classic IEEE-754 case that doesn't sum to a clean
+	// decimal (0.30000000000000004) — passing the raw float straight into
+	// the i18n template (instead of pre-formatting it) leaks that noise
+	// into the "Total Today" line shown to the user.
+	tempDir := t.TempDir()
+	now := time.Now()
+
+	records := []cost.ActivityRecord{
+		{Timestamp: now, Command: "suggest", CostUSD: 0.1},
+		{Timestamp: now, Command: "summarize-pr", CostUSD: 0.2},
+	}
+
+	manager := setupTestManager(t, tempDir, records)
+	trans := setupTestTranslations(t)
+	cmd := NewStatsCommand()
+
+	var buf bytes.Buffer
+	oldStdout := os.Stdout
+	oldColorOutput := color.Output
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	color.Output = w // fatih/color caches os.Stdout at package init, so cyan/yellow.Print* calls need the redirect spelled out separately
+
+	err := cmd.showDailyStats(manager, trans)
+
+	_ = w.Close()
+	os.Stdout = oldStdout
+	color.Output = oldColorOutput
+	_, _ = io.Copy(&buf, r)
+
+	outputStr := buf.String()
+
+	assert.NoError(t, err)
+	assert.Contains(t, outputStr, "$0.3000 USD", "the total should be rounded to 4 decimals, not the raw float")
+	assert.NotContains(t, outputStr, "0.30000000000000004", "raw float noise must not leak into the output")
 }
 
 func TestShowDailyStats_WithCacheHits(t *testing.T) {
@@ -266,6 +305,42 @@ func TestShowMonthlyStats_WithActivity(t *testing.T) {
 	total, err := manager.GetMonthlyTotal()
 	assert.NoError(t, err)
 	assert.Equal(t, 0.0050, total, "the monthly total should be 0.0050")
+}
+
+func TestShowMonthlyStats_TotalIsFormattedCleanly(t *testing.T) {
+	// Same IEEE-754 case as TestShowDailyStats_TotalIsFormattedCleanly,
+	// but for the "Total This Month" / "Average per day" lines.
+	tempDir := t.TempDir()
+	now := time.Now()
+
+	records := []cost.ActivityRecord{
+		{Timestamp: time.Date(now.Year(), now.Month(), 1, 10, 0, 0, 0, time.Local), Command: "suggest", CostUSD: 0.1},
+		{Timestamp: time.Date(now.Year(), now.Month(), 2, 10, 0, 0, 0, time.Local), Command: "suggest", CostUSD: 0.2},
+	}
+
+	manager := setupTestManager(t, tempDir, records)
+	trans := setupTestTranslations(t)
+	cmd := NewStatsCommand()
+
+	var buf bytes.Buffer
+	oldStdout := os.Stdout
+	oldColorOutput := color.Output
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	color.Output = w // fatih/color caches os.Stdout at package init, so cyan/yellow.Print* calls need the redirect spelled out separately
+
+	err := cmd.showMonthlyStats(manager, trans, false)
+
+	_ = w.Close()
+	os.Stdout = oldStdout
+	color.Output = oldColorOutput
+	_, _ = io.Copy(&buf, r)
+
+	outputStr := buf.String()
+
+	assert.NoError(t, err)
+	assert.Contains(t, outputStr, "$0.3000 USD", "the monthly total should be rounded to 4 decimals, not the raw float")
+	assert.NotContains(t, outputStr, "0.30000000000000004", "raw float noise must not leak into the output")
 }
 
 func TestShowMonthlyStats_GroupsByDay(t *testing.T) {

--- a/internal/services/issue_template_service.go
+++ b/internal/services/issue_template_service.go
@@ -211,7 +211,8 @@ func (s *IssueTemplateService) InitializeTemplates(ctx context.Context, force bo
 
 	logger.Info(ctx, "template initialization complete", "created", created, "skipped", skipped)
 	if created == 0 && skipped > 0 {
-		return domainErrors.NewAppError(domainErrors.TypeConfiguration, "templates_already_exist", nil)
+		return domainErrors.NewAppError(domainErrors.TypeConfiguration, "issue templates already exist", nil).
+			WithSuggestion("Use --force to overwrite the existing templates")
 	}
 	return nil
 }

--- a/internal/services/issue_template_service_test.go
+++ b/internal/services/issue_template_service_test.go
@@ -137,7 +137,7 @@ func TestIssueTemplateService_FilesystemOps(t *testing.T) {
 	t.Run("InitializeTemplates - Already exists", func(t *testing.T) {
 		err := service.InitializeTemplates(context.Background(), false)
 		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "CONFIGURATION: templates_already_exist")
+		assert.Contains(t, err.Error(), "CONFIGURATION: issue templates already exist")
 
 		err = service.InitializeTemplates(context.Background(), true)
 		assert.NoError(t, err)


### PR DESCRIPTION
## Description
I improved the CLI error reporting across several commands. Specifically, I added `ui.PrintError` calls in `internal/commands/config/init.go` and `internal/commands/config/set.go` to ensure error messages are displayed to the user before the command exits. In `internal/commands/issues/templates.go`, I updated error handling to use `ui.HandleAppError` for a more consistent user experience. Additionally, the `templates_already_exist` error in `internal/services/issue_template_service.go` now includes a suggestion to use the `--force` flag.

I also addressed an issue with the display of monetary and percentage values in the `stats` command. The `internal/commands/stats/stats.go` file was modified to format all relevant float values (totals, averages, projections, cache hit rates, saved amounts, and average costs) using `fmt.Sprintf("%.4f", value)` before they are passed to the i18n templates. This prevents floating-point precision artifacts (e.g., `0.30000000000000004`) from appearing in the user-facing output, ensuring clean and consistent numerical presentation.

Fixes # (issue)

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
- [x] Unit tests
- [ ] Integration tests
- [ ] Manual test: (describe below)

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Test Plan & Evidence

### Suggested Manual Verification
- [x] **API/Backend**: Attach JSON response or logs as evidence of correct behavior
- [x] **Performance**: Ensure no significant latency increase
- [x] **Unit Tests**: Run `go test ./...` and ensure all tests pass
- [x] **No Regressions**: Verify that related features still work as expected
