### PR TITLE
Fix: Return specific error for no new commits in release analysis

### DIFF
--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -95,6 +95,9 @@ var (
 	ErrNoChanges = NewAppError(TypeGit, "No staged changes detected", nil).
 			WithSuggestion("Stage your changes first with: git add <files>")
 
+	ErrNoCommitsSinceLastRelease = NewAppError(TypeGit, "No new commits since the last release", nil).
+					WithSuggestion("Nothing to release yet — commit some changes first")
+
 	ErrGetBranch = NewAppError(TypeGit, "Failed to get current branch", nil).
 			WithSuggestion("Make sure you are in a git repository: git status")
 

--- a/internal/services/release_service.go
+++ b/internal/services/release_service.go
@@ -118,7 +118,7 @@ func (s *ReleaseService) AnalyzeNextRelease(ctx context.Context) (*models.Releas
 	}
 
 	if len(commits) == 0 {
-		return nil, domainErrors.ErrNoChanges
+		return nil, domainErrors.ErrNoCommitsSinceLastRelease
 	}
 
 	validCommits := s.filterValidCommits(commits)

--- a/internal/services/release_service_test.go
+++ b/internal/services/release_service_test.go
@@ -105,7 +105,8 @@ func TestReleaseService_AnalyzeNextRelease(t *testing.T) {
 
 		assert.Error(t, err)
 		assert.Nil(t, release)
-		assert.Contains(t, err.Error(), "GIT: No staged changes detected")
+		assert.Contains(t, err.Error(), "GIT: No new commits since the last release",
+			"the error must be release-specific, not the commit-staging message ('git add') which doesn't apply here")
 
 		mockGit.AssertExpectations(t)
 	})


### PR DESCRIPTION
## Description
I updated the `AnalyzeNextRelease` function in the release service to return a more specific error, `ErrNoCommitsSinceLastRelease`, when no new commits are detected since the last release. Previously, the function incorrectly returned `ErrNoChanges`, which suggested a staging issue rather than a lack of new commits for a release. This change improves the clarity of error messages for users.

Fixes #

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
I updated the unit tests for `AnalyzeNextRelease` in `internal/services/release_service_test.go` to assert against the new, specific error message.

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual test: (describe below)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Test Plan & Evidence

### Suggested Manual Verification
- [x] **API/Backend**: Attach JSON response or logs as evidence of correct behavior
- [x] **Performance**: Ensure no significant latency increase
- [x] **Unit Tests**: Run `go test ./...` and ensure all tests pass
- [x] **No Regressions**: Verify that related features still work as expected
