### PR TITLE
Potential fix for code scanning alert no. 2: Arbitrary file access during archive extraction ("Zip Slip")

### DIFF
--- a/internal/services/version_checker.go
+++ b/internal/services/version_checker.go
@@ -450,10 +450,22 @@ func (v *VersionUpdater) extractZip(archivePath, destDir string) (string, error)
 		}
 	}()
 
+	cleanDestDir, err := filepath.Abs(filepath.Clean(destDir))
+	if err != nil {
+		return "", err
+	}
+
 	var binaryPath string
 	binaryName := "matecommit.exe"
 	for _, f := range r.File {
-		target := filepath.Join(destDir, f.Name)
+		if filepath.IsAbs(f.Name) {
+			return "", fmt.Errorf("invalid archive entry path: %s", f.Name)
+		}
+
+		target := filepath.Clean(filepath.Join(cleanDestDir, f.Name))
+		if target != cleanDestDir && !strings.HasPrefix(target, cleanDestDir+string(os.PathSeparator)) {
+			return "", fmt.Errorf("invalid archive entry path: %s", f.Name)
+		}
 
 		if f.FileInfo().IsDir() {
 			_ = os.MkdirAll(target, 0755)


### PR DESCRIPTION
Potential fix for [https://github.com/thomas-vilte/matecommit/security/code-scanning/2](https://github.com/thomas-vilte/matecommit/security/code-scanning/2)

To fix Zip Slip safely without changing intended functionality, validate each ZIP entry path before any filesystem operation:

1. Compute a cleaned destination root (`destDir`) absolute path.
2. For each entry:
   - Reject absolute entry names.
   - Build candidate path and clean it.
   - Ensure the cleaned candidate is within cleaned destination root using a prefix check on absolute/cleaned paths (with trailing separator boundary).
3. Only then run `MkdirAll`, `Create`, `Chmod`, etc.

In `internal/services/version_checker.go`, update `extractZip`:
- Add a canonical `cleanDestDir` once before the loop.
- Replace direct `target := filepath.Join(destDir, f.Name)` with validated path construction.
- Return an error when an entry is invalid (safer than silently skipping, and keeps extraction behavior explicit/fail-fast).

No new dependencies are required; existing imports already include `fmt`, `os`, and `filepath`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
